### PR TITLE
Use Linux USER variable for script portability in directory paths.

### DIFF
--- a/ixia-c/lab1/lab1-test-bidirectional.sh
+++ b/ixia-c/lab1/lab1-test-bidirectional.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -xe
-LabDir="/home/centos/keng-td/ixia-c"
+LabDir="/home/$USER/keng-td/ixia-c"
 LabId="lab1"
 export OTG_API="https://clab-Ixia-c-DUT-FRR-Ixia-c-Controller:8443"
 export OTG_LOCATION_P1="clab-Ixia-c-DUT-FRR-Ixia-c-Traffic-Engine-1:5551"

--- a/ixia-c/lab1/lab1-test-unidirectional.sh
+++ b/ixia-c/lab1/lab1-test-unidirectional.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -xe
-LabDir="/home/centos/keng-td/ixia-c"
+LabDir="/home/$USER/keng-td/ixia-c"
 LabId="lab1"
 export OTG_API="https://clab-Ixia-c-DUT-FRR-Ixia-c-Controller:8443"
 export OTG_LOCATION_P1="clab-Ixia-c-DUT-FRR-Ixia-c-Traffic-Engine-1:5551"

--- a/ixia-c/lab2/lab2-test-bidirectional.sh
+++ b/ixia-c/lab2/lab2-test-bidirectional.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -xe
 python3.8 -m venv keng
 source ./keng/bin/activate
-pip install snappi
+pip install snappi --quiet
 LabDir="/home/$USER/keng-td/ixia-c"
 LabId="lab2"
 TrafficEngine1SrcMac=$(jq .links[0].a.mac $LabDir/$LabId/clab-Ixia-c-DUT-FRR/topology-data.json --raw-output)

--- a/ixia-c/lab2/lab2-test-unidirectional.sh
+++ b/ixia-c/lab2/lab2-test-unidirectional.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -xe
 python3.8 -m venv keng
 source ./keng/bin/activate
-pip install snappi
+pip install snappi --quiet
 LabDir="/home/$USER/keng-td/ixia-c"
 LabId="lab2"
 TrafficEngine1SrcMac=$(jq .links[0].a.mac $LabDir/$LabId/clab-Ixia-c-DUT-FRR/topology-data.json --raw-output)

--- a/keng/lab2/lab2-test-apply-config.sh
+++ b/keng/lab2/lab2-test-apply-config.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -xe
-LabDir="/home/ubuntu/keng-td/keng"
+LabDir="/home/$USER/keng-td/keng"
 LabId="lab2"
 export OTG_API="https://localhost:8443"
 #

--- a/keng/lab2/lab2-test-show-results.sh
+++ b/keng/lab2/lab2-test-show-results.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -xe
-LabDir="/home/ubuntu/keng-td/keng"
+LabDir="/home/$USER/keng-td/keng"
 LabId="lab2"
 export OTG_API="https://localhost:8443"
 #

--- a/keng/lab2/lab2-test-start-protocol.sh
+++ b/keng/lab2/lab2-test-start-protocol.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -xe
-LabDir="/home/ubuntu/keng-td/keng"
+LabDir="/home/$USER/keng-td/keng"
 LabId="lab2"
 export OTG_API="https://localhost:8443"
 #

--- a/keng/lab2/lab2-test-start-traffic.sh
+++ b/keng/lab2/lab2-test-start-traffic.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -xe
-LabDir="/home/ubuntu/keng-td/keng"
+LabDir="/home/$USER/keng-td/keng"
 LabId="lab2"
 export OTG_API="https://localhost:8443"
 #


### PR DESCRIPTION
Suppress pip install detailed output.